### PR TITLE
feat(circleci): update AWS auth to use OIDC role

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,7 @@ jobs:
       - image: 916869144969.dkr.ecr.us-east-1.amazonaws.com/customink/ruby:focal-<< parameters.ruby-version >>
         user: root
         aws_auth:
-          aws_access_key_id: ${PRODUCTION_AWS_ACCESS_KEY_ID}
-          aws_secret_access_key: ${PRODUCTION_AWS_SECRET_ACCESS_KEY}
+          oidc_role_arn: arn:aws:iam::916869144969:role/customink-continuous-integration
         environment:
           RAILS_ENV: test
           RACK_ENV: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,7 @@ jobs:
     docker:
       - image: 916869144969.dkr.ecr.us-east-1.amazonaws.com/customink/ruby:focal-3.0
         aws_auth:
-          aws_access_key_id: ${PRODUCTION_AWS_ACCESS_KEY_ID}
-          aws_secret_access_key: ${PRODUCTION_AWS_SECRET_ACCESS_KEY}
+          oidc_role_arn: arn:aws:iam::916869144969:role/customink-continuous-integration
         user: root
     steps:
       - checkout


### PR DESCRIPTION


### Stakeholder Overview _[(learn more)](https://app.getguru.com/card/TGyLkrnc/Pull-Review-Stakeholder-Overview)_
Updated the CircleCI configuration to replace the AWS access key and secret access key with an OIDC role ARN for authentication.